### PR TITLE
Add optional alarm_name_suffix variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to master bra
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | alarm\_actions | Actions to execute when this alarm transitions. | `list(string)` | n/a | yes |
+| alarm\_name\_suffix | Suffix for cloudwatch alarm name to ensure uniqueness. | `string` | `""` | no |
 | disable | Disable health checks | `bool` | `false` | no |
 | dns\_name | Fully-qualified domain name (FQDN) to create. | `string` | n/a | yes |
 | environment | Environment tag (e.g. prod). | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_route53_health_check" "https" {
 resource "aws_cloudwatch_metric_alarm" "http" {
   provider = aws.us-east-1
 
-  alarm_name        = "${var.dns_name}-status-http"
+  alarm_name        = "${var.dns_name}-status-http${var.alarm_name_suffix}"
   alarm_description = "Route53 health check status for ${var.dns_name}"
   count             = var.disable ? 0 : 1
 
@@ -64,7 +64,7 @@ resource "aws_cloudwatch_metric_alarm" "http" {
 resource "aws_cloudwatch_metric_alarm" "https" {
   provider = aws.us-east-1
 
-  alarm_name        = "${var.dns_name}-status-https"
+  alarm_name        = "${var.dns_name}-status-https${var.alarm_name_suffix}"
   alarm_description = "Route53 health check status for ${var.dns_name}"
   count             = var.disable ? 0 : 1
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "dns_name" {
   type        = string
 }
 
+variable "alarm_name_suffix" {
+  description = "Suffix for cloudwatch alarm name to ensure uniqueness."
+  type = string
+  default = ""
+}
+
 variable "alarm_actions" {
   description = "Actions to execute when this alarm transitions."
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -10,8 +10,8 @@ variable "dns_name" {
 
 variable "alarm_name_suffix" {
   description = "Suffix for cloudwatch alarm name to ensure uniqueness."
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "alarm_actions" {


### PR DESCRIPTION
We ran into a situation with conflicting/duplicate cloudwatch metric alarm names when trying to use this module to monitor multiple paths associated with a CloudFront distribution. The CloudFront distribution has a single dns record, but different paths can be associated with different custom origins (e.g., S3 bucket, ALB), each of which we would like to monitor with a health check.

Cloudwatch metric alarm names must be unique within an AWS account. This change adds an optional alarm_name_suffix variable that would allow the user to customize the alarm name for the purposes of uniqueness.

The underlying problem to solve is the ability to generate unique cloudwatch metric alarm names with this module. This PR was an initial attempt at a solution, but there may also be preferred alternatives to achieve this.