### PR TITLE
add the ability to toggle checks and alarms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         keys:
         - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
     - run:
-        command: pre-commit run --all-files
+        command: pre-commit run --all-files --show-diff-on-failure
         name: Run pre-commit tests
     - save_cache:
         key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:efb1042e31538677779971798e0912390f699e72
+      image: trussworks/circleci:03d0d0dcd05dad6cc03b570e5128c735ea90c80f
     steps:
     - checkout
     - restore_cache:
@@ -18,7 +18,7 @@ jobs:
         paths:
         - ~/.cache/pre-commit
 references:
-  circleci: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+  circleci: trussworks/circleci:03d0d0dcd05dad6cc03b570e5128c735ea90c80f
 version: 2.1
 workflows:
   validate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,12 +12,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.26.0
+    rev: v0.28.1
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.51.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -16,40 +16,55 @@ module "route53_health_check" {
 
 ## Terraform Versions
 
-Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to master branch.
-
+Terraform 0.12. Pin module version to ~> 2.X. Submit pull-requests to main branch.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0 |
-| aws.us-east-1 | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | >= 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_metric_alarm.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_route53_health_check.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check) | resource |
+| [aws_route53_health_check.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| alarm\_actions | Actions to execute when this alarm transitions. | `list(string)` | n/a | yes |
-| alarm\_name\_suffix | Suffix for cloudwatch alarm name to ensure uniqueness. | `string` | `""` | no |
-| disable | Disable health checks | `bool` | `false` | no |
-| dns\_name | Fully-qualified domain name (FQDN) to create. | `string` | n/a | yes |
-| environment | Environment tag (e.g. prod). | `string` | n/a | yes |
-| failure\_threshold | Failure Threshold (must be less than or equal to 10) | `string` | `"3"` | no |
-| health\_check\_path | Resource Path to check | `string` | `""` | no |
-| health\_check\_regions | AWS Regions for health check | `list(string)` | <pre>[<br>  "us-east-1",<br>  "us-west-1",<br>  "us-west-2"<br>]</pre> | no |
-| request\_interval | Request Interval (must be 10 or 30) | `string` | `"30"` | no |
+| <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | Actions to execute when this alarm transitions. | `list(string)` | n/a | yes |
+| <a name="input_alarm_name_suffix"></a> [alarm\_name\_suffix](#input\_alarm\_name\_suffix) | Suffix for cloudwatch alarm name to ensure uniqueness. | `string` | `""` | no |
+| <a name="input_disable"></a> [disable](#input\_disable) | Disable health checks | `bool` | `false` | no |
+| <a name="input_dns_name"></a> [dns\_name](#input\_dns\_name) | Fully-qualified domain name (FQDN) to create. | `string` | n/a | yes |
+| <a name="input_enable_http_alarm"></a> [enable\_http\_alarm](#input\_enable\_http\_alarm) | Enable the HTTP health check metric alarm. Only works when enable\_http\_check is true. | `bool` | `true` | no |
+| <a name="input_enable_http_check"></a> [enable\_http\_check](#input\_enable\_http\_check) | Enable the HTTP health check. | `bool` | `true` | no |
+| <a name="input_enable_https_alarm"></a> [enable\_https\_alarm](#input\_enable\_https\_alarm) | Enable the HTTPS health check metric alarm. Only works when enable\_https\_check is true. | `bool` | `true` | no |
+| <a name="input_enable_https_check"></a> [enable\_https\_check](#input\_enable\_https\_check) | Enable the HTTPS health check. | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment tag (e.g. prod). | `string` | n/a | yes |
+| <a name="input_failure_threshold"></a> [failure\_threshold](#input\_failure\_threshold) | Failure Threshold (must be less than or equal to 10) | `string` | `"3"` | no |
+| <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | Resource Path to check | `string` | `""` | no |
+| <a name="input_health_check_regions"></a> [health\_check\_regions](#input\_health\_check\_regions) | AWS Regions for health check | `list(string)` | <pre>[<br>  "us-east-1",<br>  "us-west-1",<br>  "us-west-2"<br>]</pre> | no |
+| <a name="input_request_interval"></a> [request\_interval](#input\_request\_interval) | Request Interval (must be 10 or 30) | `string` | `"30"` | no |
 
 ## Outputs
 
-No output.
-
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "aws_route53_health_check" "http" {
   request_interval  = var.request_interval
   regions           = var.health_check_regions
   measure_latency   = true
-  count             = var.disable ? 0 : 1
+  count             = var.enable_http_check && !var.disable ? 1 : 0
 
   tags = {
     Name        = "${var.dns_name}-http"
@@ -25,7 +25,7 @@ resource "aws_route53_health_check" "https" {
   request_interval  = var.request_interval
   regions           = var.health_check_regions
   measure_latency   = true
-  count             = var.disable ? 0 : 1
+  count             = var.enable_https_check && !var.disable ? 1 : 0
 
   tags = {
     Name        = "${var.dns_name}-https"
@@ -39,8 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "http" {
 
   alarm_name        = "${var.dns_name}-status-http${var.alarm_name_suffix}"
   alarm_description = "Route53 health check status for ${var.dns_name}"
-  count             = var.disable ? 0 : 1
-
+  count             = var.enable_http_alarm && var.enable_http_check && !var.disable ? 1 : 0
 
   namespace   = "AWS/Route53"
   metric_name = "HealthCheckStatus"
@@ -66,7 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "https" {
 
   alarm_name        = "${var.dns_name}-status-https${var.alarm_name_suffix}"
   alarm_description = "Route53 health check status for ${var.dns_name}"
-  count             = var.disable ? 0 : 1
+  count             = var.enable_https_alarm && var.enable_https_check && !var.disable ? 1 : 0
 
   namespace   = "AWS/Route53"
   metric_name = "HealthCheckStatus"
@@ -86,4 +85,3 @@ resource "aws_cloudwatch_metric_alarm" "https" {
   ok_actions                = var.alarm_actions
   insufficient_data_actions = var.alarm_actions
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,26 @@ variable "disable" {
   default     = false
 }
 
+variable "enable_http_check" {
+  description = "Enable the HTTP health check."
+  type        = bool
+  default     = true
+}
+
+variable "enable_https_check" {
+  description = "Enable the HTTPS health check."
+  type        = bool
+  default     = true
+}
+
+variable "enable_http_alarm" {
+  description = "Enable the HTTP health check metric alarm. Only works when enable_http_check is true."
+  type        = bool
+  default     = true
+}
+
+variable "enable_https_alarm" {
+  description = "Enable the HTTPS health check metric alarm. Only works when enable_https_check is true."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This adds the ability to selectively enable the HTTP and HTTP checks and alarms. All checks and alarms are enabled by default to maintain backward compatibility. Each alarm can only be enabled if the corresponding check is also enabled.